### PR TITLE
Destructure Axios Function Parameters

### DIFF
--- a/modules/api-proxy/plugin.js
+++ b/modules/api-proxy/plugin.js
@@ -22,9 +22,9 @@ export default (ctx, inject) => {
         baseURL: `http://localhost:${port}`,
         headers
       })
-      return http(url, options, method, data).then(r => r.data)
+      return http({ url, options, method, data }).then(r => r.data)
     }
-    return axios(url, options, method, data).then(r => r.data)
+    return axios({ url, options, method, data }).then(r => r.data)
   }
 
   /**


### PR DESCRIPTION
The API proxy was performing an HTTP GET request, regardless of the method I was using. This was resolved by destructing the Axios function parameters.

I confirmed that this works for the scenario:

```
return axios({ url, options, method, data }).then(r => r.data)
```

But I have not fully vetted the scenario within the `process.server` code block:

```
return http({ url, options, method, data }).then(r => r.data)
```

Thank you!